### PR TITLE
create rake task for resetting primary keys of all tables

### DIFF
--- a/lib/tasks/import_all.rake
+++ b/lib/tasks/import_all.rake
@@ -6,7 +6,8 @@ namespace :csv_load do
     "invoices",
     "items",
     "merchants",
-    "transactions"
+    "transactions",
+    "reset_primary_keys"
   ] do
   end
   puts "Seeded it all bro!"

--- a/lib/tasks/import_customers.rake
+++ b/lib/tasks/import_customers.rake
@@ -7,7 +7,6 @@ namespace :csv_load do
     csv = CSV.parse(csv_text, :headers => true, :encoding => "ISO-8859-1")
     csv.each do |row|
       t = Customer.new
-      t.id = row["id"]
       t.first_name = row["first_name"]
       t.last_name = row["last_name"]
       t.created_at = row["created_at"]

--- a/lib/tasks/import_invoices.rake
+++ b/lib/tasks/import_invoices.rake
@@ -7,7 +7,6 @@ namespace :csv_load do
     csv = CSV.parse(csv_text, :headers => true, :encoding => "ISO-8859-1")
     csv.each do |row|
       t = Invoice.new
-      t.id = row["id"]
       t.customer_id = row["customer_id"]
       t.status = row["status"]
       t.created_at = row["created_at"]

--- a/lib/tasks/import_items.rake
+++ b/lib/tasks/import_items.rake
@@ -7,7 +7,6 @@ namespace :csv_load do
     csv = CSV.parse(csv_text, :headers => true, :encoding => "ISO-8859-1")
     csv.each do |row|
       t = Item.new
-      t.id = row["id"]
       t.name = row["name"]
       t.description = row["description"]
       t.unit_price = row["unit_price"]

--- a/lib/tasks/import_merchants.rake
+++ b/lib/tasks/import_merchants.rake
@@ -7,7 +7,6 @@ namespace :csv_load do
     csv = CSV.parse(csv_text, :headers => true, :encoding => "ISO-8859-1")
     csv.each do |row|
       t = Merchant.new
-      t.id = row["id"]
       t.name = row["name"]
       t.created_at = row["created_at"]
       t.updated_at = row["updated_at"]

--- a/lib/tasks/import_transactions.rake
+++ b/lib/tasks/import_transactions.rake
@@ -8,7 +8,6 @@ namespace :csv_load do
     csv.each do |row|
       #this is a transaction object that is being created, through the class, Transaction(our model)
       t = Transaction.new
-      t.id = row["id"]
       t.invoice_id = row["invoice_id"]
       t.credit_card_number = row["credit_card_number"]
       t.credit_card_expiration_date = row["credit_card_expiration_date"]

--- a/lib/tasks/reset_primary_keys.rake
+++ b/lib/tasks/reset_primary_keys.rake
@@ -1,0 +1,12 @@
+namespace :csv_load do
+  desc "Reset primary key sequences for specified tables"
+  task reset_primary_keys: :environment do 
+    # Reset primary key for the 'table_name' table
+    ActiveRecord::Base.connection.execute("SELECT setval('customers_id_seq', (SELECT MAX(id) FROM customers));")
+    ActiveRecord::Base.connection.execute("SELECT setval('invoice_items_id_seq', (SELECT MAX(id) FROM invoice_items));")
+    ActiveRecord::Base.connection.execute("SELECT setval('invoices_id_seq', (SELECT MAX(id) FROM invoices));")
+    ActiveRecord::Base.connection.execute("SELECT setval('items_id_seq', (SELECT MAX(id) FROM items));")
+    ActiveRecord::Base.connection.execute("SELECT setval('merchants_id_seq', (SELECT MAX(id) FROM merchants));")
+    ActiveRecord::Base.connection.execute("SELECT setval('transactions_id_seq', (SELECT MAX(id) FROM transactions));")
+  end
+end


### PR DESCRIPTION
Created a rake task that will reset the primary key of all tables so that when new objects are created of any class, the database will generate ids in a sequential and continuous manner.