### PR TITLE
sad path code and tests for new merchant with empty text field

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -38,7 +38,12 @@ class Admin::MerchantsController < ApplicationController
   end
 
   def create
-    Merchant.create!(name: params[:new_company_name], enabled: false)
-    redirect_to "/admin/merchants"
+    if params[:new_company_name] != ""
+      Merchant.create!(name: params[:new_company_name], enabled: false)
+      redirect_to "/admin/merchants"
+    elsif params[:new_company_name] == ""
+      redirect_to "/admin/merchants/new"
+      flash[:alert] = "Company name cannot be empty"
+    end  
   end
 end

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -8,7 +8,6 @@
 <h3><u>Create a New Company</u></h3>
 
 <%= form_with url: "/admin/merchants", method: :post, data: {turbo: false}, local: true do |m| %>
-  <%= m.hidden_field :item_add, value: "Add_item" %>
   <%= m.label "New Company Name" %>
   <%= m.text_field :new_company_name %>
   <%= m.submit "Submit" %>

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -22,5 +22,15 @@ RSpec.describe "merchant new page" do
       expect(page).to have_content("Best Company Ever")
       expect(Merchant.count).to eq(5)
     end
+
+    it "redirects me to the merchants new page and displays a flash message when I try to submit a new company with no name in the text field" do
+      visit "admin/merchants/new"
+
+      fill_in :new_company_name, with: ""
+      click_on("Submit")
+      expect(page).to have_current_path("/admin/merchants/new")
+      expect(page).to have_content("Company name cannot be empty")
+      expect(Merchant.count).to eq(4)
+    end
   end
 end


### PR DESCRIPTION
wrote code and tests to address a sad path where a user tries to create a new company without entering anything into the field box on admin/merchants/new.